### PR TITLE
Issue 12 - Game Loop: Part 1 (Justin's Part)

### DIFF
--- a/components/game/game.js
+++ b/components/game/game.js
@@ -16,7 +16,7 @@ const Game = () => {
   // Build Card Deck
   const suites = ['spades', 'clubs', 'diamonds', 'hearts'];
   // 3-10 are normal cards, 11 is Jack, 12 is Queen, 13 is King, 14 is Ace, 15 is 2.
-  const numbers = ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15'];
+  const numbers = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
   let value = 1; // 3 of spades is the lowest card
   const deck = numbers.map((number, idx) => suites.map((suite, i) => ({ number, suite, value: value++ }))).flat();
 

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -113,7 +113,12 @@ const Game = () => {
    */
   const changeTurn = () => {
     console.log('Changing Players Turn');
-    setPlayerTurn(playerTurn === 3 ? 0 : playerTurn + 1);
+    const nextTurn = playerTurn === 3 ? 0 : playerTurn + 1;
+    if (hands[nextTurn].hand.length === 0) {
+      setPlayerTurn(nextTurn + 1);
+    } else {
+      setPlayerTurn(nextTurn);
+    }
   }
 
   /**
@@ -130,6 +135,7 @@ const Game = () => {
       setComboStatus(false);
     }
   }
+
   /**
    * @description - Validates the submitted combo against the last combo played.
    * @param {Object[]} combo - Array of card objects
@@ -181,20 +187,13 @@ const Game = () => {
   const passTurn = () => {
     changeTurn();
     setComboStatus(true);
+    hands[0].hand = [];
+    setHands(hands);
   }
 
   const changeCombo = (e) => {
     setComboSelect(e.target.value);
     setCurrentTurnCombo(e.target.value);
-  }
-
-  /**
-   * @description Reshuffle deck to test combos.
-   */
-  const reshuffleDeck = () => {
-    shuffleDeck(false);
-    setComboStatus(null);
-    onShuffleClick();
   }
 
   // Only show shuffle button at start or end of game
@@ -256,7 +255,10 @@ const Game = () => {
           </form>
           {comboIsValid && <h2 className={gameStyles.validCombo}>Combo Choice is correct. Try making another combo or reshuffling the deck for new cards.</h2>}
 
-          <h2>Previous Played Combo: <ul>{listOfCards}</ul></h2>
+          <div className={gameStyles.middlePile}>
+            <h2>Middle Pile</h2>
+            <ul>{listOfCards}</ul>
+          </div>
         </div>
         
       }

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -53,7 +53,7 @@ const Game = () => {
      * NOTE: This is logic for AI players
      */
     if (playerTurn !== 0) {
-      let valueToBeat = previousPlayedCombo.length === 0 ? 0 : previousPlayedCombo[previousPlayedCombo.length - 1].value
+      let valueToBeat = previousPlayedCombo.length === 0 ? 0 : previousPlayedCombo[previousPlayedCombo.length - 1].value;
 
       const currHand = hands[playerTurn].hand;
       const lowestCard = currHand.reduce((lowest, curr) => {

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -14,8 +14,10 @@ const Game = () => {
   const [comboIsValid, setComboStatus] = useState(null);
   const [currentTurnCombo, setCurrentTurnCombo] = useState('single');
   const [previousPlayedCombo, setPreviousPlayedCombo] = useState([]);
-
   const [selectCombo, setComboSelect] = useState('single');
+
+  const [endCycleClause, setEndCycleClause] = useState(false);
+
   // Build Card Deck
   const suites = ['spades', 'clubs', 'diamonds', 'hearts'];
   // 3-10 are normal cards, 11 is Jack, 12 is Queen, 13 is King, 14 is Ace, 15 is 2.
@@ -28,13 +30,30 @@ const Game = () => {
   }, []);
 
   useEffect(() => {
+    if (!hands) {
+      return;
+    }
      /**
+      * @description End logic if all hands have passed
+      * NOTE: This logic is not complete and does not cater to all use cases.
+      * NOTE: THIS IS STRICTLY FOR TESTING
+      */
+
+    let checkEndCycle = hands.filter((hand) => hand.skipped !== true);
+
+    // if checkEndCycle is true after checking all hands for skipped property
+    // do not run AI logic.
+    if (checkEndCycle.length <= 1) {
+      setEndCycleClause(true);
+      return;
+    }
+
+    /**
      * @description Prompt ai logic
      * NOTE: This is logic for AI players
      */
-
     if (playerTurn !== 0) {
-      let valueToBeat = previousPlayedCombo === 0 ? 0 : previousPlayedCombo[previousPlayedCombo.length - 1].value
+      let valueToBeat = previousPlayedCombo.length === 0 ? 0 : previousPlayedCombo[previousPlayedCombo.length - 1].value
 
       const currHand = hands[playerTurn].hand;
       const lowestCard = currHand.reduce((lowest, curr) => {
@@ -50,7 +69,7 @@ const Game = () => {
       } else {
         // NOTE: Will cause endless cycle of passing until there is game logic to recognize next cycle.
         console.log(`Player ${playerTurn + 1} passes.`);
-        passTurn();
+        passTurn(playerTurn);
       }
     }
   }, [playerTurn]);
@@ -102,15 +121,25 @@ const Game = () => {
     }, 1000);
   };
 
-
   /**
    * @description Changes the player turn to the next player.
+   * Goal is to find the player that has the key 'skipped' === false
    */
   const changeTurn = () => {
-    console.log('Changing Players Turn');
-    const nextTurn = playerTurn === 3 ? 0 : playerTurn + 1;
-    const nextTurnCanPlay = hands[nextTurn].hand.length > 0;
-    setPlayerTurn(nextTurnCanPlay ? nextTurn : nextTurn + 1);
+    let nextTurn = false;
+    let markerTurn = playerTurn + 1;
+    while (!nextTurn) {
+      if (markerTurn > 3) {
+        markerTurn = 0;
+      }
+
+      if (hands[markerTurn].skipped) {
+        markerTurn++;
+      } else {
+        nextTurn = true;
+      }
+    }
+    setPlayerTurn(markerTurn);
   }
 
   /**
@@ -176,11 +205,11 @@ const Game = () => {
   /**
    * @description Updates the player turn to the next player.
    */
-  const passTurn = () => {
-    changeTurn();
-    setComboStatus(true);
-    hands[0].hand = [];
+  const passTurn = (playerTurn) => {
+    hands[playerTurn].skipped = true;
     setHands(hands);
+    setComboStatus(true);
+    changeTurn();
   }
 
   const changeCombo = (e) => {
@@ -222,8 +251,12 @@ const Game = () => {
       {deckIsShuffled &&
         <div>
           <h2 className={gameStyles.turnIndicator}>
-            <span>{playerTurn === 0 ? 'Your' : `Player ${playerTurn + 1}'s`} turn.</span>
-            {playerTurn !== 0 && <span> Thinking... <span className={gameStyles.loading}></span></span>}
+            {endCycleClause ? 
+            <span>End of Turn Cycle...resetting...</span> : 
+            <div>
+              <span>{playerTurn === 0 ? 'Your' : `Player ${playerTurn + 1}'s`} turn.</span>
+              {playerTurn !== 0 && <span> Thinking... <span className={gameStyles.loading}></span></span>}
+            </div>}
           </h2>
           <h2>Select a combo thats fits {selectCombo}</h2>
           <h3>Your Hand:</h3>
@@ -245,8 +278,7 @@ const Game = () => {
               <option value='double sequence'>Double Sequence</option>
             </select>
           </form>
-          {comboIsValid && <h2 className={gameStyles.validCombo}>Combo Choice is correct. Try making another combo or reshuffling the deck for new cards.</h2>}
-
+          {comboIsValid && <h2 className={gameStyles.validCombo}>Combo Choice is correct.</h2>}
           <div className={gameStyles.middlePile}>
             <h2>Middle Pile</h2>
             <ul>{listOfCards}</ul>

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -77,6 +77,7 @@ const Game = () => {
       showIntro(false);
       shuffleDeck(true);
     }, 1000);
+    gameLoop();
   };
 
   /**
@@ -113,12 +114,8 @@ const Game = () => {
    * @param {Object[]} combo - Array of card objects
    */
   const requestCombo = (combo, combination) => {
-    console.log('Request Combo starting...');
-    console.log('Combination to play is: ', currentTurnCombo);
-    console.log('Player is playing: ', combo);
     // Check if combo is valid
     if(previousPlayedCombo.length === 0 || (validateCombo(combo, combination) && compareCombo(previousPlayedCombo[previousPlayedCombo.length - 1].value, combo))) {
-      console.log('Played higher combo, keep moving...');
       // Accept combo and set player turn
       setComboStatus(true);
       setPreviousPlayedCombo(combo);
@@ -145,7 +142,7 @@ const Game = () => {
    */
   const compareCombo = (currentHighestValue, combo) => {
     const highestValueOfCombo = highestValue(combo);
-    return highestValueOfCombo > currentHighestValue;
+    return highestValueOfCombo.value > currentHighestValue;
   }
 
   /**
@@ -174,15 +171,22 @@ const Game = () => {
   const shuffleBtn = deckIsShuffled ? null : <button className={gameStyles.shuffleBtn} onClick={onShuffleClick}>Shuffle Deck</button>;
 
   /**
+   * @description Prompt ai logic
+   * @param {integer} playerTurn
    * NOTE: This is logic for AI players
    */
-  if(playerTurn !== 0) {
-    // TODO: Simulate player's turn
-    // For testing right now, I'm just playing the lowest single card until we write the logic for the AI
-    // TODO: Once we have a more comprehensive AI, we can update the combination type.
+  const promptAI = (playerTurn) => {
+    console.log(`Player ${playerTurn + 1}'s`);
+    let valueToBeat;
+    if (previousPlayedCombo.length === 0) {
+      valueToBeat = 0;
+    } else {
+      valueToBeat = previousPlayedCombo[previousPlayedCombo.length - 1].value;
+    }
+
     const currHand = hands[playerTurn].hand;
     const lowestCard = currHand.reduce((lowest, curr) => {
-      if(curr.value < lowest) {
+      if(curr.value < lowest && curr.value > valueToBeat) {
         return curr.value;
       }
       return lowest;
@@ -191,6 +195,22 @@ const Game = () => {
 
     // TODO: Remove when done testing. This is mocking a single card play
     setTimeout(() => requestCombo([currHand.find((card) => card.value === lowestCard)], 'single'), 5000);
+    return;
+  }
+
+  /**
+   * @description Simple Game loop: 4 turns
+   */
+  const gameLoop = () => {
+    console.log('Game Loop');
+    let turnCycle = 0;
+    while (turnCycle !== 4) {
+      console.log('Current Turn: ', playerTurn);
+      if (playerTurn !== 0) {
+        promptAI(playerTurn);
+      }
+      turnCycle++;
+    }
   }
 
   const listOfCards = previousPlayedCombo.map((card, idx) => {
@@ -210,6 +230,8 @@ const Game = () => {
       </li>
     );
   });
+
+  console.log(hands);
 
   return (
     <game>
@@ -250,7 +272,7 @@ const Game = () => {
           </form>
           {comboIsValid && <h2 className={gameStyles.validCombo}>Combo Choice is correct. Try making another combo or reshuffling the deck for new cards.</h2>}
 
-          <h2>Previous Played Combo: {listOfCards}</h2>
+          <h2>Previous Played Combo: <ul>{listOfCards}</ul></h2>
         </div>
         
       }

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -39,7 +39,7 @@ const Game = () => {
       * NOTE: THIS IS STRICTLY FOR TESTING
       */
 
-    let checkEndCycle = hands.filter((hand) => hand.skipped !== true);
+    let checkEndCycle = hands.filter(hand => hand.skipped !== true);
 
     // if checkEndCycle is true after checking all hands for skipped property
     // do not run AI logic.

--- a/components/game/game.module.scss
+++ b/components/game/game.module.scss
@@ -94,3 +94,16 @@ $primary-color: #2600ff;
   color: white;
   padding: 1rem;
 }
+
+.middlePile {
+  margin: 1rem;
+  padding: 1rem;
+  border: 2px solid #2600ff;
+  text-align: center;
+  width: fit-content;
+}
+
+.middlePile > h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}

--- a/components/gameComponents/hand.js
+++ b/components/gameComponents/hand.js
@@ -11,7 +11,7 @@ const icons = {
 
 // Prop
 // Need to check if allowed to shed a card or not.
-const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo, passTurn }) => {
+const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo, passTurn, setUserInput }) => {
   const [hand, setHand] = useState(cards);
   const [combo, setCombo] = useState([]);
   const [hasReset, resetCombo] = useState(false);

--- a/components/gameComponents/hand.js
+++ b/components/gameComponents/hand.js
@@ -1,16 +1,7 @@
 import {  React, useState } from "react";
 import styles from "@/app/page.module.css";
-import { mapCard } from "../utilities/card";
+import { mapCard, icons } from "../utilities/card";
 
-const icons = {
-  'hearts': '♥',
-  'diamonds': '♦',
-  'spades': '♠',
-  'clubs': '♣',
-}
-
-// Prop
-// Need to check if allowed to shed a card or not.
 const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo, passTurn }) => {
   const [hand, setHand] = useState(cards);
   const [combo, setCombo] = useState([]);
@@ -119,6 +110,7 @@ const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo,
       </li>
     );
   });
+
   // Line 122: Removed sentence 'Try a different combo or pass' and replaced with 'Try a different combo or press Change Combo Type' for this PR specifically.
   return (
     <div>

--- a/components/gameComponents/hand.js
+++ b/components/gameComponents/hand.js
@@ -118,7 +118,7 @@ const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo,
       {isMyTurn &&
       <div className={styles.handBtns}>
         <button disabled={!isMyTurn} onClick={finalizeTurn}>Finalize Turn</button>
-        <button disabled={!isMyTurn} onClick={() => passTurn()}>Pass Turn</button>
+        <button disabled={!isMyTurn} onClick={() => passTurn(playerTurn)}>Pass Turn</button>
       </div>}
     </div>
   );

--- a/components/gameComponents/hand.js
+++ b/components/gameComponents/hand.js
@@ -11,11 +11,17 @@ const icons = {
 
 // Prop
 // Need to check if allowed to shed a card or not.
-const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo, passTurn, setUserInput }) => {
+const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo, passTurn }) => {
   const [hand, setHand] = useState(cards);
   const [combo, setCombo] = useState([]);
   const [hasReset, resetCombo] = useState(false);
   const isMyTurn = playerTurn === 0;
+
+  const resetHand = () => {
+    hand.forEach(card => card.selected = false);
+    setCombo([]);
+    resetCombo(true);
+  }
 
   // Update hand after changes.
   // NOTE: Apparently this might not be best practice, and some people suggest handling all
@@ -27,24 +33,14 @@ const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo,
   // FIXME: I don't love that I had to use a dumb hasReset flag to get this to work...
   if(!isMyTurn && !hasReset) {
     // Reset selected cards
-    hand.forEach(card => card.selected = false);
-    setCombo([]);
-    resetCombo(true);
+    resetHand();
   }
   
-  // Remove 1 card.
-  const removeCard = (removedCard, e) => {
-    e.preventDefault();
-    const newHand = hand.filter((card) => (card.value != removedCard.value) ? true : false);
-    setHand(newHand);
-  }
-
   // Use a flag to indicated selected/nonselected.
   // Dictionary for combo actions.
   // Need logic to handle the combo being accepted or denied.
   // Set up cypress
   // Logic to manipulate combo state.
-
   // Game send function to hand to ask for combo.
   const selectCard = (selectedCard, e) => {
     e.preventDefault();
@@ -102,8 +98,8 @@ const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo,
       console.log('Hand submitted nothing, combo not sent to game component.');
       return;
     }
-
     requestCombo(combo.map((card) => { return { number: card.number, suite: card.suite, value: card.value } }), currentTurnCombo);
+    resetHand();
   } 
 
   const listOfCards = hand.map((card, idx) => {
@@ -129,10 +125,11 @@ const Hand = ({ cards, playerTurn, comboIsValid, requestCombo, currentTurnCombo,
       <ul className={styles.hand}>{listOfCards}</ul>
 
       {comboIsValid === false && <div>Invalid Combo. Try a different combo or press Change Combo Type.</div>}
+      {isMyTurn &&
       <div className={styles.handBtns}>
         <button disabled={!isMyTurn} onClick={finalizeTurn}>Finalize Turn</button>
         <button disabled={!isMyTurn} onClick={() => passTurn()}>Pass Turn</button>
-      </div>
+      </div>}
     </div>
   );
 }

--- a/components/utilities/card.js
+++ b/components/utilities/card.js
@@ -2,15 +2,15 @@
 // rank (string)
 
 export const mapCard = (number) => {
-  if (number === '11') {
+  if (number === 11) {
     return 'J';
-  } else if (number === '12') {
+  } else if (number === 12) {
     return 'Q';
-  } else if (number === '13') {
+  } else if (number === 13) {
     return 'K';
-  } else if (number === '14') {
+  } else if (number === 14) {
     return 'A';
-  } else if (number === '15') {
+  } else if (number === 15) {
     return '2';
   } else {
     return number;

--- a/components/utilities/card.js
+++ b/components/utilities/card.js
@@ -1,6 +1,3 @@
-// suit (string)
-// rank (string)
-
 export const mapCard = (number) => {
   if (number === 11) {
     return 'J';
@@ -16,6 +13,13 @@ export const mapCard = (number) => {
     return number;
   }
 }
+
+export const icons = {
+  'hearts': '♥',
+  'diamonds': '♦',
+  'spades': '♠',
+  'clubs': '♣',
+};
 
 export const makeCard = (suit, rank) => {
   return {

--- a/components/utilities/combination.js
+++ b/components/utilities/combination.js
@@ -1,4 +1,3 @@
-// Function validateCombo that takes in an array of cards which is the current players choice of cards, and matches it to the current cycles combination. 
 export const dictionaryCombinations = {
   'single': {
     isValid: (cards) => cards.length === 1,
@@ -75,3 +74,19 @@ export const dictionaryCombinations = {
     }
   }
 }
+
+/**
+ * @description Returns card object with highest value from array of card objects
+ * @param {Object[]} combo - Array of card objects 
+ */
+export const highestValue = (combo) => {
+  const result = combo.reduce((acc, cardObj) => {
+    if (cardObj.value > acc.value) {
+      return cardObj;
+    } else {
+      return acc;
+    }
+  });
+  return result;
+}
+

--- a/components/utilities/combination.js
+++ b/components/utilities/combination.js
@@ -77,7 +77,7 @@ export const dictionaryCombinations = {
 
 /**
  * @description Returns card object with highest value from array of card objects
- * @param {Object[]} combo - Array of card objects 
+ * @param {object[]} combo - Array of card objects 
  */
 export const highestValue = (combo) => {
   const result = combo.reduce((acc, cardObj) => {


### PR DESCRIPTION
Partially resolves https://github.com/jduong09/thirteen/issues/12

## Changes/Additions
- Change numbers array so values 3-15 are not strings, but integers to facilitate faster logic on mapping.
- Added logic to resolve #12 task - "Validating player 2s choice for valid combo and higher value."
- Allow user to pass turn, effectively removing them from turn cycle until cycle is complete

## Todo/Bugs
- If CPU has no move to play (CPU has no card to beat previous played card), browser will throw runtime error. (URGENT)
- CPU needs feature to pass turn
- Game component needs feature to recognize end of turn cycle, trigger cycle reset

## How To Test
- Checkout to `issue-12--game-loop-justin` and pull changes with `git pull`
- Navigate to `localhost:3000` in your browser
- Open developer tools and navigate to 'console' on browser to keep a better track of CPU moves and turns being changed.
- Shuffle the deck. The browser will display a hand of 13 cards as well as indicate which player is going first (whoever has the 3 of spades).
- Either the CPU will have 3 of spades and game cycle will begin immediately. You can keep track of CPU moves until it is user turn.
- Submit an invalid combo, will trigger error message.
- Submit a valid combo, will update middle pile, and remove card from user hand.
- After valid combo submission, turn will change and CPU will play.
- Pressing 'pass turn' will remove cards from hand, and change turn, follow console and middle pile UI to see CPU play cards until runtime error.