### PR TITLE
Issue 6 - Hand Sorting

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -35,6 +35,10 @@
   justify-content: center;
 }
 
+.cardTopLeft.red, .cardBottomRight.red {
+  color: red;
+}
+
 .cardBottomRight > span {
   transform: rotate(180deg);
 }
@@ -46,3 +50,8 @@
   margin-right: 1rem;
 }
 
+.select {
+  border: 1px solid blue;
+  padding: .25rem .5rem;
+  margin: 1rem .5rem;
+}

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -198,7 +198,7 @@ const Game = () => {
 
   // Only show shuffle button at start or end of game
   const shuffleBtn = deckIsShuffled ? null : <button className={gameStyles.shuffleBtn} onClick={onShuffleClick}>Shuffle Deck</button>;
- 
+
   const listOfCards = previousPlayedCombo.map((card, idx) => {
     const cardDisplay = mapCard(card.number);
     return (


### PR DESCRIPTION
Resolves #6 

## Changes/Additions
- Added new function to hand component to sort the player's cards:
  - Can sort by group: quadruplets, triplets, doubles, then single cards
  - Can sort by strength: highest to lowest in terms of value
- Temporarily added a red call to help see the difference in cards