### PR TITLE
Game Functionality: Slams

### DIFF
--- a/components/game/game.js
+++ b/components/game/game.js
@@ -225,7 +225,6 @@ const Game = () => {
   const onShuffleClick = () => {
     showIntro(true);
 
-    /*
     const tempHands = [
       {player: 0, hand: [], skipped: false, winner: false},
       {player: 1, hand: [], skipped: false, winner: false},
@@ -242,97 +241,9 @@ const Game = () => {
       };
       
     });
-    */
 
-    // Created 4 hands, with user hand having 5+ pairs to utilize slams for testing.
-    const tempHands = [
-      {
-        player: 0, 
-        hand: [
-          {number: 3, suite: 'spades', value: 1, selected: false},
-          {number: 3, suite: 'hearts', value: 4, selected: false},
-          {number: 3, suite: 'diamonds', value: 3, selected: false},
-          {number: 4, suite: 'spades', value: 5, selected: false},
-          {number: 6, suite: 'hearts', value: 16, selected: false},
-          {number: 8, suite: 'diamonds', value: 23, selected: false},
-          {number: 7, suite: 'clubs', value: 18, selected: false},
-          {number: 6, suite: 'clubs', value: 14, selected: false},
-          {number: 8, suite: 'clubs', value: 22, selected: false},
-          {number: 7, suite: 'spades', value: 17, selected: false},
-          {number: 4, suite: 'clubs', value: 6, selected: false},
-          {number: 5, suite: 'clubs', value: 10, selected: false},
-          {number: 5, suite: 'diamonds', value: 11, selected: false},
-          {number: 3, suite: 'clubs', value: 2, selected: false},
-        ],
-        skipped: false, 
-        winner: false},
-      {
-        player: 1, 
-        hand: [
-          {number: 14, suite: 'spades', value: 45, selected: false},
-          {number: 13, suite: 'clubs', value: 42, selected: false},
-          {number: 11, suite: 'clubs', value: 34, selected: false},
-          {number: 10, suite: 'diamonds', value: 31, selected: false},
-          {number: 10, suite: 'hearts', value: 32, selected: false},
-          {number: 14, suite: 'spades', value: 45, selected: false},
-          {number: 12, suite: 'diamonds', value: 39, selected: false},
-          {number: 11, suite: 'spades', value: 33, selected: false},
-          {number: 15, suite: 'hearts', value: 52, selected: false},
-          {number: 12, suite: 'spades', value: 37, selected: false},
-          {number: 10, suite: 'clubs', value: 30, selected: false},
-          {number: 14, suite: 'spades', value: 45, selected: false},
-          {number: 5, suite: 'hearts', value: 12, selected: false},
-          {number: 13, suite: 'hearts', value: 44, selected: false},
-        ], 
-        skipped: false, 
-        winner: false
-      },
-      {
-        player: 2, 
-        hand: [
-          {number: 12, suite: 'hearts', value: 40, selected: false}, 
-          {number: 13, suite: 'hearts', value: 44, selected: false},
-          {number: 14, suite: 'diamonds', value: 47, selected: false},
-          {number: 6, suite: 'spades', value: 13, selected: false},
-          {number: 15, suite: 'spades', value: 49, selected: false},
-          {number: 7, suite: 'hearts', value: 20, selected: false},
-          {number: 5, suite: 'spades', value: 9, selected: false},
-          {number: 9, suite: 'clubs', value: 26, selected: false},
-          {number: 4, suite: 'hearts', value: 8, selected: false},
-          {number: 14, suite: 'spades', value: 45, selected: false},
-          {number: 14, suite: 'clubs', value: 46, selected: false},
-          {number: 8, suite: 'spades', value: 21, selected: false},
-          {number: 7, suite: 'diamonds', value: 19, selected: false}
-        ], 
-        skipped: false, 
-        winner: false
-      },
-      {
-        player: 3, 
-        hand: [
-          {number: 10, suite: 'spades', value: 29, selected: false},
-          {number: 13, suite: 'diamonds', value: 43, selected: false},
-          {number: 9, suite: 'spades', value: 25, selected: false},
-          {number: 9, suite: 'hearts', value: 28, selected: false},
-          {number: 9, suite: 'diamonds', value: 27, selected: false},
-          {number: 9, suite: 'clubs', value: 26, selected: false},
-          {number: 8, suite: 'hearts', value: 24, selected: false},
-          {number: 15, suite: 'diamonds', value: 51, selected: false},
-          {number: 3, suite: 'clubs', value: 2, selected: false},
-          {number: 4, suite: 'diamonds', value: 7, selected: false},
-          {number: 6, suite: 'diamonds', value: 15, selected: false},
-          {number: 14, suite: 'hearts', value: 48, selected: false},
-          {number: 13, suite: 'spades', value: 41, selected: false}
-        ], 
-        skipped: false, 
-        winner: false
-      },
-    ];
-
-    setPlayerTurn(0);
-    setTurnMessage('Your Turn.');
     setHands(tempHands);
-    // setNewRound(true);
+    setNewRound(true);
 
     setTimeout(() => {
       showIntro(false);
@@ -368,9 +279,6 @@ const Game = () => {
    * @returns {Boolean}
    */
   const validateCombo = (combo, combination) => {
-    console.log('Combo', combo);
-    console.log('Combination', combination);
-    console.log('Previous:', previousPlayedCombo);
     if (combination === '') {
       setTurnMessage('Your Turn: Set combination type before playing.');
       return;

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -7,6 +7,15 @@ import { dictionaryCombinations, highestValue } from '@/components/utilities/com
 import { mapCard, icons } from '../utilities/card';
 import { aiMoves, aiPossibleCombinations, determineHardestMove } from '../utilities/ai';
 
+/** 
+ * For Testing Purposes on this branch specifically
+ * @description variables used to manipulate previousPlayedCombo 
+*/
+
+const comboSingleTwo = [{number: 15, suite: 'hearts', value: 52, selected: false}];
+const comboPairTwo = [{number: 15, suite: 'hearts', value: 52, selected: false}, {number: 15, suite: 'spades', value: 49, selected: false}];
+const comboTripletTwo = [{number: 15, suite: 'hearts', value: 52, selected: false}, {number: 15, suite: 'spades', value: 49, selected: false}, {number: 15, suite: 'diamonds', value: 51, selected: false}];
+
 const Game = () => {
   const [shuffledDeck, setDeck] = useState([]);
   const [deckIsShuffled, shuffleDeck] = useState(false);
@@ -14,9 +23,9 @@ const Game = () => {
   const [playerTurn, setPlayerTurn] = useState(0);
   const [hands, setHands] = useState([]);
   const [comboIsValid, setComboStatus] = useState(null);
-  const [currentTurnCombo, setCurrentTurnCombo] = useState('');
-  const [currentTurnLength, setCurrentTurnLength] = useState(1);
-  const [previousPlayedCombo, setPreviousPlayedCombo] = useState([]);
+  const [currentTurnCombo, setCurrentTurnCombo] = useState('pair');
+  const [currentTurnLength, setCurrentTurnLength] = useState(2);
+  const [previousPlayedCombo, setPreviousPlayedCombo] = useState(comboPairTwo);
   const [selectCombo, setComboSelect] = useState('');
   const [endCycleClause, setEndCycleClause] = useState(null);
   const [winnerClause, setWinnerClause] = useState(null);
@@ -60,7 +69,6 @@ const Game = () => {
       console.log(`Player ${checkWinner[0].player.toString()} wins!`);
       return;
     }
-
 
     /**
      * @description End logic if all hands have passed
@@ -221,6 +229,7 @@ const Game = () => {
   const onShuffleClick = () => {
     showIntro(true);
 
+    /*
     const tempHands = [
       {player: 0, hand: [], skipped: false, winner: false},
       {player: 1, hand: [], skipped: false, winner: false},
@@ -237,8 +246,97 @@ const Game = () => {
       };
       
     });
+    */
+
+    // Created 4 hands, with user hand having 5+ pairs to utilize slams for testing.
+    const tempHands = [
+      {
+        player: 0, 
+        hand: [
+          {number: 3, suite: 'spades', value: 1, selected: false},
+          {number: 3, suite: 'hearts', value: 4, selected: false},
+          {number: 3, suite: 'diamonds', value: 3, selected: false},
+          {number: 4, suite: 'spades', value: 5, selected: false},
+          {number: 6, suite: 'hearts', value: 16, selected: false},
+          {number: 8, suite: 'diamonds', value: 23, selected: false},
+          {number: 7, suite: 'clubs', value: 18, selected: false},
+          {number: 6, suite: 'clubs', value: 14, selected: false},
+          {number: 8, suite: 'clubs', value: 22, selected: false},
+          {number: 7, suite: 'spades', value: 17, selected: false},
+          {number: 4, suite: 'clubs', value: 6, selected: false},
+          {number: 5, suite: 'clubs', value: 10, selected: false},
+          {number: 5, suite: 'diamonds', value: 11, selected: false},
+          {number: 3, suite: 'clubs', value: 2, selected: false},
+        ],
+        skipped: false, 
+        winner: false},
+      {
+        player: 1, 
+        hand: [
+          {number: 14, suite: 'spades', value: 45, selected: false},
+          {number: 13, suite: 'clubs', value: 42, selected: false},
+          {number: 11, suite: 'clubs', value: 34, selected: false},
+          {number: 10, suite: 'diamonds', value: 31, selected: false},
+          {number: 10, suite: 'hearts', value: 32, selected: false},
+          {number: 14, suite: 'spades', value: 45, selected: false},
+          {number: 12, suite: 'diamonds', value: 39, selected: false},
+          {number: 11, suite: 'spades', value: 33, selected: false},
+          {number: 15, suite: 'hearts', value: 52, selected: false},
+          {number: 12, suite: 'spades', value: 37, selected: false},
+          {number: 10, suite: 'clubs', value: 30, selected: false},
+          {number: 14, suite: 'spades', value: 45, selected: false},
+          {number: 5, suite: 'hearts', value: 12, selected: false},
+          {number: 13, suite: 'hearts', value: 44, selected: false},
+        ], 
+        skipped: false, 
+        winner: false
+      },
+      {
+        player: 2, 
+        hand: [
+          {number: 12, suite: 'hearts', value: 40, selected: false}, 
+          {number: 13, suite: 'hearts', value: 44, selected: false},
+          {number: 14, suite: 'diamonds', value: 47, selected: false},
+          {number: 6, suite: 'spades', value: 13, selected: false},
+          {number: 15, suite: 'spades', value: 49, selected: false},
+          {number: 7, suite: 'hearts', value: 20, selected: false},
+          {number: 5, suite: 'spades', value: 9, selected: false},
+          {number: 9, suite: 'clubs', value: 26, selected: false},
+          {number: 4, suite: 'hearts', value: 8, selected: false},
+          {number: 14, suite: 'spades', value: 45, selected: false},
+          {number: 14, suite: 'clubs', value: 46, selected: false},
+          {number: 8, suite: 'spades', value: 21, selected: false},
+          {number: 7, suite: 'diamonds', value: 19, selected: false}
+        ], 
+        skipped: false, 
+        winner: false
+      },
+      {
+        player: 3, 
+        hand: [
+          {number: 10, suite: 'spades', value: 29, selected: false},
+          {number: 13, suite: 'diamonds', value: 43, selected: false},
+          {number: 9, suite: 'spades', value: 25, selected: false},
+          {number: 9, suite: 'hearts', value: 28, selected: false},
+          {number: 9, suite: 'diamonds', value: 27, selected: false},
+          {number: 9, suite: 'clubs', value: 26, selected: false},
+          {number: 8, suite: 'hearts', value: 24, selected: false},
+          {number: 15, suite: 'diamonds', value: 51, selected: false},
+          {number: 3, suite: 'clubs', value: 2, selected: false},
+          {number: 4, suite: 'diamonds', value: 7, selected: false},
+          {number: 6, suite: 'diamonds', value: 15, selected: false},
+          {number: 14, suite: 'hearts', value: 48, selected: false},
+          {number: 13, suite: 'spades', value: 41, selected: false}
+        ], 
+        skipped: false, 
+        winner: false
+      },
+    ];
+
+    setPlayerTurn(0);
+    setTurnMessage('Your Turn.');
     setHands(tempHands);
-    setNewRound(true);
+    // setNewRound(true);
 
     setTimeout(() => {
       showIntro(false);
@@ -274,11 +372,42 @@ const Game = () => {
    * @returns {Boolean}
    */
   const validateCombo = (combo, combination) => {
+    console.log('Combo', combo);
+    console.log('Combination', combination);
+    console.log('Previous:', previousPlayedCombo);
     if (combination === '') {
       setTurnMessage('Your Turn: Set combination type before playing.');
       return;
+    } else if (combination === 'single' && previousPlayedCombo.length === 1 && previousPlayedCombo[0].number === 15) {
+      if (dictionaryCombinations['double sequence'].isValid(combo) && combo.length >= 6) {
+        setCurrentTurnCombo('double sequence');
+        return true;
+      } else if (dictionaryCombinations['quartet'].isValid(combo)) {
+        setCurrentTurnCombo('quartet');
+        return true;
+      } else {
+        return (dictionaryCombinations[combination].isValid(combo) && compareCombo(previousPlayedCombo[previousPlayedCombo.length - 1].value, combo));
+      }
+    } else if (combination === 'pair' && previousPlayedCombo.length === 2 && previousPlayedCombo.every((card) => card.number === 15)) {
+      if (dictionaryCombinations['double sequence'].isValid(combo) && combo.length >= 8) {
+        setCurrentTurnCombo('double sequence');
+        return true;
+      } else if (dictionaryCombinations['quartet'].isValid(combo)) {
+        setCurrentTurnCombo('quartet');
+        return true;
+      } else {
+        return (dictionaryCombinations[combination].isValid(combo) && compareCombo(previousPlayedCombo[previousPlayedCombo.length - 1].value, combo));
+      }
+    } else if (combination === 'triplet' && previousPlayedCombo.length === 3 && previousPlayedCombo.every((card) => card.number === 15)) {
+      if (dictionaryCombinations['double sequence'].isValid(combo) && combo.length >= 10) {
+        setCurrentTurnCombo('double sequence');
+        return true;
+      } else {
+        return (dictionaryCombinations[combination].isValid(combo) && compareCombo(previousPlayedCombo[previousPlayedCombo.length - 1].value, combo));
+      }
+    } else {
+      return dictionaryCombinations[combination].isValid(combo) && compareCombo(previousPlayedCombo[previousPlayedCombo.length - 1].value, combo);
     }
-    return dictionaryCombinations[combination].isValid(combo);
   }
 
   /**
@@ -287,8 +416,9 @@ const Game = () => {
    */
   const requestCombo = (combo, combination) => {
     // Check if combo is valid
-    if((previousPlayedCombo.length === 0 && validateCombo(combo, combination)) || (validateCombo(combo, combination) && compareCombo(previousPlayedCombo[previousPlayedCombo.length - 1].value, combo))) {
+    if((previousPlayedCombo.length === 0 && validateCombo(combo, combination)) || (validateCombo(combo, combination))) {
       // Accept combo and set player turn
+
       setComboStatus(true);
       console.log(`PLAYER ${playerTurn + 1} plays: ${combo.map((card) => `${card.number} of ${card.suite}`).join(", ")}\n\n`);
       setPreviousPlayedCombo(combo);

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -23,6 +23,12 @@ const Game = () => {
   const [playerTurn, setPlayerTurn] = useState(0);
   const [hands, setHands] = useState([]);
   const [comboIsValid, setComboStatus] = useState(null);
+  /**
+   * Testing issue-29--slams requires changing state of currentTurnCombo, currentTurnLength and previousPlayedCombo
+   * currentTurnCombo = 'single' | 'pair' | 'triplet'
+   * currentTurnLength = 1 | 2 | 3
+   * previousPlayedCombo = comboSingleTwo | comboPairTwo | comboTripletTwo
+   */
   const [currentTurnCombo, setCurrentTurnCombo] = useState('pair');
   const [currentTurnLength, setCurrentTurnLength] = useState(2);
   const [previousPlayedCombo, setPreviousPlayedCombo] = useState(comboPairTwo);

--- a/components/game/game.js
+++ b/components/game/game.js
@@ -11,11 +11,7 @@ import { aiMoves, aiPossibleCombinations, determineHardestMove } from '../utilit
  * For Testing Purposes on this branch specifically
  * @description variables used to manipulate previousPlayedCombo 
 */
-
-const comboSingleTwo = [{number: 15, suite: 'hearts', value: 52, selected: false}];
-const comboPairTwo = [{number: 15, suite: 'hearts', value: 52, selected: false}, {number: 15, suite: 'spades', value: 49, selected: false}];
-const comboTripletTwo = [{number: 15, suite: 'hearts', value: 52, selected: false}, {number: 15, suite: 'spades', value: 49, selected: false}, {number: 15, suite: 'diamonds', value: 51, selected: false}];
-
+ß
 const Game = () => {
   const [shuffledDeck, setDeck] = useState([]);
   const [deckIsShuffled, shuffleDeck] = useState(false);
@@ -23,15 +19,9 @@ const Game = () => {
   const [playerTurn, setPlayerTurn] = useState(0);
   const [hands, setHands] = useState([]);
   const [comboIsValid, setComboStatus] = useState(null);
-  /**
-   * Testing issue-29--slams requires changing state of currentTurnCombo, currentTurnLength and previousPlayedCombo
-   * currentTurnCombo = 'single' | 'pair' | 'triplet'
-   * currentTurnLength = 1 | 2 | 3
-   * previousPlayedCombo = comboSingleTwo | comboPairTwo | comboTripletTwo
-   */
-  const [currentTurnCombo, setCurrentTurnCombo] = useState('pair');
-  const [currentTurnLength, setCurrentTurnLength] = useState(2);
-  const [previousPlayedCombo, setPreviousPlayedCombo] = useState(comboPairTwo);
+  const [currentTurnCombo, setCurrentTurnCombo] = useState('');
+  const [currentTurnLength, setCurrentTurnLength] = useState(null);
+  const [previousPlayedCombo, setPreviousPlayedCombo] = useState([]);
   const [selectCombo, setComboSelect] = useState('');
   const [endCycleClause, setEndCycleClause] = useState(null);
   const [winnerClause, setWinnerClause] = useState(null);


### PR DESCRIPTION
Resolves #29 

## Changes/Additions
- Added logic for approving slams ruleset.

## Hot To Test
- To test the three different slam rules (slam vs one 2, slam vs pair of 2s, slam vs triple 2s), tester must change the beginning state for currentTurnCombo, currentTurnLength, previousPlayedCombo
- Checkout to `issue-29--slams` and pull changes with `git pull`
- Navigate to `localhost:3000` in your browser
- Shuffle deck, first turn is user.
- depending on which slam rule testing, either follow up the previous played combo with double sequence or quartet.
- Test correct/incorrect combos.
- Following correct combo, one of the AI should be able to follow up with a double sequence or quartet.
- Following one round of testing, change state and restart test.

## Notes
- A single 2 may be beaten by any double sequence of 3+ pairs or a quartet
- A pair of 2s may be beaten by any double sequence of 4+ pairs or a quartet
- A triplet of 2s may be beaten by any double sequence of 5+ pairs